### PR TITLE
avoid once warnings when assigning EXPORT* vars

### DIFF
--- a/lib/Sub/Exporter/Progressive.pm
+++ b/lib/Sub/Exporter/Progressive.pm
@@ -18,6 +18,7 @@ sub import {
 
    my $full_exporter;
    no strict 'refs';
+   no warnings 'once';
    @{"${inner_target}::EXPORT_OK"} = @{$export_data->{exports}};
    @{"${inner_target}::EXPORT"} = @{$export_data->{defaults}};
    %{"${inner_target}::EXPORT_TAGS"} = %{$export_data->{tags}};


### PR DESCRIPTION
Normally, the EXPORT\* vars will be immune to 'once' warnings.  In perl
5.25.6, EXPORT_TAGS lost its immunity to the warning.  While that will
most likely be fixed, we can just be safe and stop relying on having
that special cased.
